### PR TITLE
Add Clone method to WithJSON wrapper

### DIFF
--- a/wrapper.go
+++ b/wrapper.go
@@ -42,4 +42,8 @@ func (w *WithJSON[T]) Set(data T) {
 	w.Data = data
 }
 
-type PayloadFactory[P Wrapper] func() P
+// Clone returns a new empty wrapper of the same type
+func (w *WithJSON[T]) Clone() *WithJSON[T] {
+	var zero T
+	return NewWrapper(zero)
+}

--- a/wrapper_test.go
+++ b/wrapper_test.go
@@ -141,3 +141,25 @@ func TestWrapperEdgeCases(t *testing.T) {
 		}
 	})
 }
+
+func TestClone(t *testing.T) {
+	wUser := NewWrapper(User{
+		Name:        "Microwave Vertex Marble",
+		Description: "Full him bale me within. As far to canoe wad its it.",
+		Categories:  []string{"musical instruments", "bicycles and accessories", "books"},
+		Price:       46.06,
+		Features:    []string{"user-friendly", "compact"},
+		Color:       "navy",
+		Material:    "granite",
+	})
+
+	clone := wUser.Clone()
+
+	if wUser == clone {
+		t.Error("Cloned wrapper is the same as the original")
+	}
+
+	if clone.Get().Name == wUser.Get().Name {
+		t.Error("Cloned wrapper need to be empty")
+	}
+}


### PR DESCRIPTION
Introduced a Clone method to the WithJSON wrapper to create a new, empty instance of the same type. Added associated unit tests to ensure the functionality works as expected and doesn't duplicate existing data.