### PR TITLE
Rename `wrapper` to `packio`, unify format helpers, and update docume…

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,19 +1,16 @@
-// Package wrapper provides generic serialization wrappers for your types.
+// Package packio provides generic serialization wrappers for your types.
 //
 // The package exposes a single generic interface, Serializer[T], which defines
 // Serialize and Deserialize methods to convert the wrapped value to and from
 // bytes, plus Get/Set accessors and Clone for deep-copy semantics.
 //
-// You typically construct a wrapper with NewWrapper, optionally selecting the
+// You typically construct a wrapper with New, optionally selecting the
 // format (JSON by default):
 //
-//	w := wrapper.NewWrapper(MyType{})               // JSON by default
-//	y := wrapper.NewWrapper(MyType{}, wrapper.YAML) // YAML
-//	t := wrapper.NewWrapper(MyType{}, wrapper.TOML) // TOML
-//
-// For direct format construction you can also use NewYAMLWrapper and
-// NewTOMLWrapper helpers.
+//	w := packio.New(MyType{})               // JSON by default
+//	y := packio.New(MyType{}, packio.YAML) // YAML
+//	t := packio.New(MyType{}, packio.TOML) // TOML
 //
 // Note: This package does not provide concurrency control; protect shared
 // access with synchronization if you mutate wrappers from multiple goroutines.
-package wrapper
+package packio

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
-module github.com/inovacc/wrapper
+module github.com/inovacc/packio
 
-go 1.24
+go 1.23
 
 require (
 	github.com/pelletier/go-toml/v2 v2.2.4

--- a/json.go
+++ b/json.go
@@ -1,4 +1,4 @@
-package wrapper
+package packio
 
 import "encoding/json"
 
@@ -23,14 +23,14 @@ func (w *WithJSON[T]) Set(data T) { w.Data = data }
 func (w *WithJSON[T]) Clone(empty bool) Serializer[T] {
 	if empty {
 		var zero T
-		return NewWrapper(zero)
+		return New(zero)
 	}
 
 	// Marshal the original data
 	data, err := json.Marshal(w.Data)
 	if err != nil {
 		var zero T
-		return NewWrapper(zero)
+		return New(zero)
 	}
 
 	// Create a new instance
@@ -39,8 +39,8 @@ func (w *WithJSON[T]) Clone(empty bool) Serializer[T] {
 	// Unmarshal into the new instance
 	if err := json.Unmarshal(data, &newData); err != nil {
 		var zero T
-		return NewWrapper(zero)
+		return New(zero)
 	}
 
-	return NewWrapper(newData)
+	return New(newData)
 }

--- a/packio.go
+++ b/packio.go
@@ -1,4 +1,4 @@
-package wrapper
+package packio
 
 type SerdeType int
 
@@ -25,10 +25,10 @@ type Serializer[T any] interface {
 	Set(data T)
 }
 
-// NewWrapper creates a new wrapper instance.
+// New creates a new wrapper instance.
 // If a format is provided, it will be used; otherwise it defaults to JSON.
 // The return type is the unified Serializer[T] interface for flexible usage.
-func NewWrapper[T any](data T, format ...SerdeType) Serializer[T] {
+func New[T any](data T, format ...SerdeType) Serializer[T] {
 	f := JSON
 	if len(format) > 0 {
 		f = format[0]

--- a/packio_test.go
+++ b/packio_test.go
@@ -1,4 +1,4 @@
-package wrapper
+package packio
 
 import (
 	"encoding/json"
@@ -118,7 +118,7 @@ func TestWrapper(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create wrapper
-			p := NewWrapper(tt.input)
+			p := New(tt.input)
 
 			// Test Serialize (JSON)
 			data, err := p.Serialize()
@@ -135,7 +135,7 @@ func TestWrapper(t *testing.T) {
 			}
 
 			// Test Deserialize
-			newWrapper := NewWrapper(User{})
+			newWrapper := New(User{})
 			if err := newWrapper.Deserialize(data); err != nil {
 				t.Errorf("Deserialize() error = %v", err)
 				return
@@ -152,7 +152,7 @@ func TestWrapper(t *testing.T) {
 
 func TestWrapperEdgeCases(t *testing.T) {
 	t.Run("Deserialize invalid JSON", func(t *testing.T) {
-		w := NewWrapper(User{})
+		w := New(User{})
 
 		err := w.Deserialize([]byte(`{"invalid json`))
 		if err == nil {
@@ -161,7 +161,7 @@ func TestWrapperEdgeCases(t *testing.T) {
 	})
 
 	t.Run("Deserialize empty JSON", func(t *testing.T) {
-		w := NewWrapper(User{})
+		w := New(User{})
 
 		err := w.Deserialize([]byte(`{}`))
 		if err != nil {
@@ -170,7 +170,7 @@ func TestWrapperEdgeCases(t *testing.T) {
 	})
 
 	t.Run("Deserialize with invalid types", func(t *testing.T) {
-		w := NewWrapper(User{})
+		w := New(User{})
 
 		err := w.Deserialize([]byte(`{"price": "not a number"}`))
 		if err == nil {
@@ -179,7 +179,7 @@ func TestWrapperEdgeCases(t *testing.T) {
 	})
 
 	t.Run("Deserialize with null values", func(t *testing.T) {
-		w := NewWrapper(User{})
+		w := New(User{})
 
 		err := w.Deserialize([]byte(`{"name": null, "price": null}`))
 		if err != nil {
@@ -189,7 +189,7 @@ func TestWrapperEdgeCases(t *testing.T) {
 }
 
 func TestCloneFull(t *testing.T) {
-	wUser := NewWrapper(User{
+	wUser := New(User{
 		Name:        "Microwave Vertex Marble",
 		Description: "Full him bale me within. As far to canoe wad its it.",
 		Categories:  []string{"musical instruments", "bicycles and accessories", "books"},
@@ -208,7 +208,7 @@ func TestCloneFull(t *testing.T) {
 }
 
 func TestCloneEmpty(t *testing.T) {
-	wUser := NewWrapper(User{
+	wUser := New(User{
 		Name:        "Microwave Vertex Marble",
 		Description: "Full him bale me within. As far to canoe wad its it.",
 		Categories:  []string{"musical instruments", "bicycles and accessories", "books"},
@@ -227,7 +227,7 @@ func TestCloneEmpty(t *testing.T) {
 }
 
 func TestCloneDeepCopy(t *testing.T) {
-	original := NewWrapper(User{
+	original := New(User{
 		Categories: []string{"cat1", "cat2"},
 		Features:   []string{"feat1", "feat2"},
 	})
@@ -248,7 +248,7 @@ func TestCloneDeepCopy(t *testing.T) {
 
 func TestEmptyWrapperWithSet(t *testing.T) {
 	// Create an empty wrapper
-	emptyWrapper := NewWrapper(User{})
+	emptyWrapper := New(User{})
 
 	// Prepare test data
 	testUser := User{
@@ -283,7 +283,7 @@ func TestEmptyWrapperWithSet(t *testing.T) {
 	}
 
 	// Create another empty wrapper and deserialize the data
-	verifyWrapper := NewWrapper(User{})
+	verifyWrapper := New(User{})
 	if err := verifyWrapper.Deserialize(data); err != nil {
 		t.Errorf("Deserialize() error after Set(): %v", err)
 	}
@@ -305,14 +305,14 @@ func TestYAMLWrapperRoundTrip(t *testing.T) {
 		Color:       "blue",
 		Material:    "paper",
 	}
-	w := NewYAMLWrapper(u)
+	w := New(u, YAML)
 
 	b, err := w.Serialize()
 	if err != nil {
 		t.Fatalf("Serialize error: %v", err)
 	}
 
-	other := NewYAMLWrapper(User{})
+	other := New(User{}, YAML)
 	if err := other.Deserialize(b); err != nil {
 		t.Fatalf("Deserialize error: %v", err)
 	}
@@ -323,7 +323,7 @@ func TestYAMLWrapperRoundTrip(t *testing.T) {
 }
 
 func TestYAMLCloneDeepCopy(t *testing.T) {
-	orig := NewYAMLWrapper(User{Categories: []string{"a", "b"}})
+	orig := New(User{Categories: []string{"a", "b"}}, YAML)
 	clone := orig.Clone(false)
 	origData := orig.Get()
 	origData.Categories[0] = "x"
@@ -344,14 +344,14 @@ func TestTOMLWrapperRoundTrip(t *testing.T) {
 		Color:       "white",
 		Material:    "paper",
 	}
-	w := NewTOMLWrapper(u)
+	w := New(u, TOML)
 
 	b, err := w.Serialize()
 	if err != nil {
 		t.Fatalf("Serialize error: %v", err)
 	}
 
-	other := NewTOMLWrapper(User{})
+	other := New(User{}, TOML)
 	if err := other.Deserialize(b); err != nil {
 		t.Fatalf("Deserialize error: %v", err)
 	}
@@ -362,7 +362,7 @@ func TestTOMLWrapperRoundTrip(t *testing.T) {
 }
 
 func TestTOMLCloneDeepCopy(t *testing.T) {
-	orig := NewTOMLWrapper(User{Features: []string{"f1", "f2"}})
+	orig := New(User{Features: []string{"f1", "f2"}}, TOML)
 	clone := orig.Clone(false)
 	origData := orig.Get()
 	origData.Features[0] = "y"

--- a/toml.go
+++ b/toml.go
@@ -1,4 +1,4 @@
-package wrapper
+package packio
 
 import (
 	"github.com/pelletier/go-toml/v2"
@@ -9,9 +9,6 @@ import (
 type WithTOML[T any] struct {
 	Data T
 }
-
-// NewTOMLWrapper creates a new instance of WithTOML
-func NewTOMLWrapper[T any](data T) *WithTOML[T] { return &WithTOML[T]{Data: data} }
 
 // Serialize implements Serializer using TOML format.
 func (w *WithTOML[T]) Serialize() ([]byte, error) { return toml.Marshal(w.Data) }
@@ -29,20 +26,20 @@ func (w *WithTOML[T]) Set(data T) { w.Data = data }
 func (w *WithTOML[T]) Clone(empty bool) Serializer[T] {
 	if empty {
 		var zero T
-		return NewTOMLWrapper(zero)
+		return New(zero, TOML)
 	}
 
 	b, err := toml.Marshal(w.Data)
 	if err != nil {
 		var zero T
-		return NewTOMLWrapper(zero)
+		return New(zero, TOML)
 	}
 
 	var newData T
 	if err := toml.Unmarshal(b, &newData); err != nil {
 		var zero T
-		return NewTOMLWrapper(zero)
+		return New(zero, TOML)
 	}
 
-	return NewTOMLWrapper(newData)
+	return New(newData, TOML)
 }

--- a/yaml.go
+++ b/yaml.go
@@ -1,4 +1,4 @@
-package wrapper
+package packio
 
 import (
 	"gopkg.in/yaml.v3"
@@ -9,9 +9,6 @@ import (
 type WithYAML[T any] struct {
 	Data T
 }
-
-// NewYAMLWrapper creates a new instance of WithYAML
-func NewYAMLWrapper[T any](data T) *WithYAML[T] { return &WithYAML[T]{Data: data} }
 
 // Serialize implements Serializer using YAML format.
 func (w *WithYAML[T]) Serialize() ([]byte, error) { return yaml.Marshal(w.Data) }
@@ -29,20 +26,20 @@ func (w *WithYAML[T]) Set(data T) { w.Data = data }
 func (w *WithYAML[T]) Clone(empty bool) Serializer[T] {
 	if empty {
 		var zero T
-		return NewYAMLWrapper(zero)
+		return New(zero, YAML)
 	}
 
 	b, err := yaml.Marshal(w.Data)
 	if err != nil {
 		var zero T
-		return NewYAMLWrapper(zero)
+		return New(zero, YAML)
 	}
 
 	var newData T
 	if err := yaml.Unmarshal(b, &newData); err != nil {
 		var zero T
-		return NewYAMLWrapper(zero)
+		return New(zero, YAML)
 	}
 
-	return NewYAMLWrapper(newData)
+	return New(newData, YAML)
 }


### PR DESCRIPTION
…ntation

Renamed the package from `wrapper` to `packio` for a more descriptive and cohesive naming. Removed redundant format-specific helpers (`NewYAMLWrapper`, `NewTOMLWrapper`), replacing them with a unified `New` function supporting dynamic format selection. Updated `go.mod` to reflect the new module name and downgraded Go version requirement to 1.23. Refactored tests, README, and examples to align with the package renaming and new API design.